### PR TITLE
fix: pinblockFormat0 according to spec

### DIFF
--- a/__tests__/pinblock.test.ts
+++ b/__tests__/pinblock.test.ts
@@ -19,3 +19,15 @@ test("pinblock", () => {
   const pinblock3 = pinBlockFormat3(pan, pin);
   console.log("pinBlockFormat3", pinblock3);
 });
+
+test("Format0 is spec compliant", () => {
+  /*
+  ISO 9564-1 Format 0
+     Values sourced from:
+     https://eftlab.com/knowledge-base/complete-list-of-pin-blocks
+   */
+  const pan = "43219876543210987";
+  const pin = "1234";
+
+  expect(pinBlockFormat0(pan, pin)).toEqual("0412AC89ABCDEF67");
+})

--- a/src/pinBlock.ts
+++ b/src/pinBlock.ts
@@ -20,7 +20,7 @@ function pinBlockFormat0(PAN: string, PIN: string) {
 
   const preparedPIN = "0" + PINLen.toString(16) + PIN.padEnd(14, "F");
 
-  const preparedPAN = PAN.slice(3, 15).padStart(16, "0");
+  const preparedPAN = PAN.slice(-13, -1).padStart(16, "0");
 
   const clearPINblock = xor(preparedPIN, preparedPAN);
 


### PR DESCRIPTION
Hey @hosseinmd

This PR should fix https://github.com/hosseinmd/data-crypto/issues/10 following the spec found in https://www.eftlab.com/knowledge-base/complete-list-of-pin-blocks